### PR TITLE
fix Error: Call to a member function add() on array..

### DIFF
--- a/Entity/BasePost.php
+++ b/Entity/BasePost.php
@@ -296,7 +296,7 @@ abstract class BasePost extends Post
     public function __clone() {
         $this->id = null;
         $this->settings = null;
-        $this->tags = [];
+        $this->tags = new ArrayCollection();
         $this->postHasCategory = new ArrayCollection();
         $this->postHasMedia = new ArrayCollection();
         $this->relatedArticles = new ArrayCollection();


### PR DESCRIPTION
fix _**Error: Call to a member function add() on array...**_ caused by $this->tags = []; should be  $this->tags = new ArrayCollection();

| Description | Status |
| --- | --- |
| Bug fix: | yes |
| Feature addition: | no |
| Backwards compatibility break: | no |
| Fixes the following tickets: | - |

FROM:

``` php
$this->tags = [];
```

TO:

``` php
$this->tags = new ArrayCollection();
```
