### PR TITLE
added addMethodCall for PostSetsHasPost compiler pass

### DIFF
--- a/DependencyInjection/Compiler/OverrideServiceCompilerPass.php
+++ b/DependencyInjection/Compiler/OverrideServiceCompilerPass.php
@@ -57,6 +57,7 @@ class OverrideServiceCompilerPass implements CompilerPassInterface
         $definition->addMethodCall('setDefaultContext', array($container->getParameter('rz.news.post_sets.default_context')));
         $definition->addMethodCall('setDefaultCollection', array($container->getParameter('rz.news.post_sets.default_collection')));
         $definition->addMethodCall('setCollectionManager', array(new Reference('sonata.classification.manager.collection')));
+        $definition->addMethodCall('setSlugify', array(new Reference($serviceId)));
         $definition->addMethodCall('setSettings', array($container->getParameter('rz.news.settings.post_sets_has_posts')));
 
 


### PR DESCRIPTION
**Fix error on PostHasSetsAdmin. setSlugify() was not called on compilerpass.**

| Description | Status |
| --- | --- |
| Bug fix: | yes |
| Feature addition: | no |
| Backwards compatibility break: | no |
| Fixes the following tickets: | - |
