### PR TITLE
Dixed getUniqueCategories method error.

### DIFF
--- a/Entity/PostHasCategoryManager.php
+++ b/Entity/PostHasCategoryManager.php
@@ -15,6 +15,7 @@ class PostHasCategoryManager extends BaseEntityManager
             ->select('c.id, c.name, p.name as parent')
             ->leftJoin('phc.category', 'c')
             ->leftJoin('c.parent', 'p')
+            ->addGroupBy('p.name')
             ->addGroupBy('c.name')
             ->getQuery()
             ->useResultCache(true, 3600);


### PR DESCRIPTION
- Fixed getUniqueCategories method error.
- Does not return all categories if a category has the same name.

| Description | Status |
| --- | --- |
| Bug fix: | yes |
| Feature addition: | no |
| Backwards compatibility break: | no |
| Fixes the following tickets: | - |
